### PR TITLE
add academicField attrubute

### DIFF
--- a/model/subject.go
+++ b/model/subject.go
@@ -25,4 +25,5 @@ type Subject struct {
 	freeDescription   string      `desc:"自由な説明"`
 	syllabusId        SyllabusId  `desc:"SyllabusId"`
 	series            string      `desc:"シリーズ"`
+	academicField     string      `desc:"分野名"`
 }


### PR DESCRIPTION
講義検索で分野名で検索できることを見落としていました。今更モデルの変更するのは憚れますが、重要な情報なので追加した方がいいと思います。

例. 数学
https://ocw.kyoto-u.ac.jp/?s=&faculty=&category=&series=&subject=mat&year=
