### PR TITLE
change the type of ids from struct to ULID

### DIFF
--- a/model/chapter.go
+++ b/model/chapter.go
@@ -6,9 +6,8 @@ import (
 	"github.com/oklog/ulid"
 )
 
-type ChapterId struct {
-	id ulid.ULID `desc:"ID"`
-}
+type ChapterId ulid.ULID
+
 type Chapter struct {
 	id            ChapterId `desc:"ID"`
 	startAt       time.Time `desc:"チャプター開始時間"`

--- a/model/faculty.go
+++ b/model/faculty.go
@@ -4,9 +4,7 @@ import (
 	"github.com/oklog/ulid"
 )
 
-type FacultyId struct {
-	id ulid.ULID `desc:"ID"`
-}
+type FacultyId ulid.ULID
 
 type Faculty struct {
 	id         FacultyId `desc:"ID"`

--- a/model/pdf.go
+++ b/model/pdf.go
@@ -4,9 +4,7 @@ import (
 	"github.com/oklog/ulid"
 )
 
-type PdfId struct {
-	id ulid.ULID `desc:"ID"`
-}
+type PdfId ulid.ULID
 
 type Pdf struct {
 	id   PdfId  `desc:"ID"`

--- a/model/subject.go
+++ b/model/subject.go
@@ -6,9 +6,7 @@ import (
 	"github.com/oklog/ulid"
 )
 
-type SubjectId struct {
-	id ulid.ULID `desc:"ID"`
-}
+type SubjectId ulid.ULID
 
 type Subject struct {
 	id                SubjectId   `desc:"ID"`

--- a/model/subpage.go
+++ b/model/subpage.go
@@ -4,9 +4,7 @@ import (
 	"github.com/oklog/ulid"
 )
 
-type SubpageId struct {
-	id ulid.ULID `desc:"ID"`
-}
+type SubpageId ulid.ULID
 
 type Subpage struct {
 	id      SubpageId `desc:"ID"`

--- a/model/syllabus.go
+++ b/model/syllabus.go
@@ -6,9 +6,8 @@ import (
 	"github.com/oklog/ulid"
 )
 
-type SyllabusId struct {
-	id ulid.ULID `desc:"ID"`
-}
+type SyllabusId ulid.ULID
+
 type Syllabus struct {
 	id                SyllabusId   `desc:"ID"`
 	facultyIds        []FacultyId  `desc:"FacultyIDs"`

--- a/model/video.go
+++ b/model/video.go
@@ -6,9 +6,7 @@ import (
 	"github.com/oklog/ulid"
 )
 
-type VideoId struct {
-	id ulid.ULID `desc:"ID"`
-}
+type VideoId ulid.ULID
 
 type Video struct {
 	id          VideoId       `desc:"ID"`


### PR DESCRIPTION
```Go
type UserId int
```
とかでintの振る舞いをする別の型UserIdが作れるらしいですね。
goの記事を見てたらIdとかはこうしてるやつが多そうなので、変更しておきます。

参考記事
- https://zenn.dev/1101hiroki_n/articles/e56b25797f9b07
- https://budougumi0617.github.io/2020/02/01/go-named-type-and-type-alias/