### PR TITLE
add duration attribute to chapter class

### DIFF
--- a/migrations/000001_create_tables.up.sql
+++ b/migrations/000001_create_tables.up.sql
@@ -65,7 +65,8 @@ CREATE TABLE IF NOT EXISTS syllabuses(
 CREATE TABLE IF NOT EXISTS chapters(
     id BINARY(16) NOT NULL PRIMARY KEY,
     video_id BINARY(16) NOT NULL,
-    start_at INT NOT NULL,
+    start_at INT,
+    duratino INT,
     topic VARCHAR(100) NOT NULL,
     thumbnail_link VARCHAR(200) NOT NULL,
     created_at DATETIME NOT NULL,

--- a/model/chapter.go
+++ b/model/chapter.go
@@ -11,6 +11,7 @@ type ChapterId ulid.ULID
 type Chapter struct {
 	id            ChapterId `desc:"ID"`
 	startAt       time.Time `desc:"チャプター開始時間"`
+	duration      int       `desc:"チャプターの長さ"`
 	topic         string    `desc:"チャプタータイトル"`
 	thumbnailLink string    `desc:"サムネイルリンク"`
 }


### PR DESCRIPTION
＃What
chapters classにdurationを追加しました。
# Why
以下の授業のように、開始時間が正しく表現されていないsubjectが多数見つかりました。chapterの長さはサイトから簡単にスクレイピングでき、そこから開始時間を逆算できるためにクラスに追加した方がいいと考えました。

https://ocw.kyoto-u.ac.jp/course/894/?video_id=8754