### PR TITLE
added ordering attribute to video class

### DIFF
--- a/migrations/000001_create_tables.up.sql
+++ b/migrations/000001_create_tables.up.sql
@@ -20,6 +20,7 @@ CREATE TABLE IF NOT EXISTS videos(
     id BINARY(16) NOT NULL PRIMARY KEY,
     subject_id BINARY(16) NOT NULL,
     title VARCHAR(191) NOT NULL,
+    ordering INT NOT NULL,
     link VARCHAR(200) NOT NULL,
     lectured_on DATE,
     video_length INT,

--- a/model/video.go
+++ b/model/video.go
@@ -11,6 +11,7 @@ type VideoId ulid.ULID
 type Video struct {
 	id          VideoId       `desc:"ID"`
 	title       string        `desc:"タイトル"`
+	ordering    int           `desc:"順番"`
 	link        string        `desc:"リンク"`
 	chapters    []Chapter     `desc:"チャプターs"`
 	facultyIds  []FacultyId   `desc:"FacultyIds"`


### PR DESCRIPTION
# what
videoクラスに順番を表すorderingのattributeを追加
# why
videoクラスが順番の情報を保持していないと、講義の順序を再現することができないため