### PR TITLE
replaced link with content in migration file

### DIFF
--- a/migrations/000001_create_tables.up.sql
+++ b/migrations/000001_create_tables.up.sql
@@ -83,7 +83,7 @@ CREATE TABLE IF NOT EXISTS resources(
 CREATE TABLE IF NOT EXISTS subpages(
     id BINARY(16) NOT NULL PRIMARY KEY,
     subject_id BINARY(16) NOT NULL,
-    link VARCHAR(200) NOT NULL,
+    content TEXT,
     created_at DATETIME NOT NULL,
     updated_at DATETIME NOT NULL,
     FOREIGN KEY (subject_id) REFERENCES subjects(id) ON DELETE RESTRICT

--- a/model/subpage.go
+++ b/model/subpage.go
@@ -23,5 +23,5 @@ func (s SubpageId) String() string {
 
 type Subpage struct {
 	id      SubpageId `desc:"ID"`
-	content string    `desc:"内容テキスト"`
+	content string    `desc:"ページ内容"`
 }


### PR DESCRIPTION
## What
- subpageがmodelではlinkのみ、migration fileではcontentのみを持っていたので、contentに統一しました。
- 変更したmigration fileに合わせてデータベースを作成し直しますので、少々お待ちください。