### PR TITLE
change TEXT to MEDIUMTEXT

### DIFF
--- a/migrations/000001_create_tables.up.sql
+++ b/migrations/000001_create_tables.up.sql
@@ -83,7 +83,7 @@ CREATE TABLE IF NOT EXISTS resources(
 CREATE TABLE IF NOT EXISTS subpages(
     id BINARY(16) NOT NULL PRIMARY KEY,
     subject_id BINARY(16) NOT NULL,
-    content TEXT,
+    content MEDIUMTEXT,
     created_at DATETIME NOT NULL,
     updated_at DATETIME NOT NULL,
     FOREIGN KEY (subject_id) REFERENCES subjects(id) ON DELETE RESTRICT


### PR DESCRIPTION
## Related Issue

## What
- TEXT型には入りきらなかったのでMEDIUMTEXT型を指定しました。

ちなみに各型の最大データ量は以下の通りです。
TEXT – 64KB (65,535 characters)
MEDIUMTEXT – 16MB (16,777,215 characters)