### PR TITLE
add product server health check workflow for PR

### DIFF
--- a/.github/workflows/check-deploy.yml
+++ b/.github/workflows/check-deploy.yml
@@ -1,0 +1,38 @@
+name: check-deploy
+on:
+  pull_request:
+    branches:
+      - main
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  pull-requests: read
+jobs:
+  health-check:
+    name: health-check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set PR number
+        run: |
+          PR_NUM=$(echo $GITHUB_REF | sed -e 's/[^0-9]//g')
+          echo "PR_NUM=$PR_NUM" >> $GITHUB_ENV
+      # PR実行時に自動的にPREVIEWサーバーにデプロイされるため、ヘルスチェックを行う
+      - name: Check the deployed service URL
+        uses: jtalk/url-health-check-action@v2
+        with:
+          url: https://${{ secrets.RENDER_SERVER_DOMAIN }}-pr-${{ env.PR_NUM }}.onrender.com/query.
+          max-attempts: 20
+          retry-delay: 20s
+    # 現時点ではrenderの標準機能で自動デプロイを行う
+    #deploy
+    #- name: Webhook
+    #  uses: zzzze/webhook-trigger@master
+    #  with:
+    #    webhook_url:
+    #- name: Wait for Deploy
+    #  uses: bounceapp/render-action@0.2.0
+    #  with:
+    #    email: ${{ secrets.RENDER_EMAIL }}
+    #    password: ${{ secrets.RENDER_PASSWORD }}
+    #    token: ${{ secrets.GITHUB_TOKEN }}
+    #    service-id:


### PR DESCRIPTION
## Related Issue

## What
- mainへのPR時にデプロイされるPREVIEWサーバーに対してヘルスチェックを行うことでデプロイの成功を簡易的に確認する
- mergeされたときのプロダクトサーバーへのデプロイはrender側で設定

## Memo
<!-- レビュワーに伝えたいことがあれば -->
