### PR TITLE
make args of subjects query required

### DIFF
--- a/graph/generated/generated.go
+++ b/graph/generated/generated.go
@@ -60,7 +60,7 @@ type ComplexityRoot struct {
 	Query struct {
 		AcademicFields func(childComplexity int) int
 		Subject        func(childComplexity int, id string) int
-		Subjects       func(childComplexity int, title *string, faculty *string, academicField *string) int
+		Subjects       func(childComplexity int, title string, faculty string, academicField string) int
 	}
 
 	RelatedSubject struct {
@@ -152,7 +152,7 @@ type ComplexityRoot struct {
 
 type QueryResolver interface {
 	Subject(ctx context.Context, id string) (*model.Subject, error)
-	Subjects(ctx context.Context, title *string, faculty *string, academicField *string) ([]*model.Subject, error)
+	Subjects(ctx context.Context, title string, faculty string, academicField string) ([]*model.Subject, error)
 	AcademicFields(ctx context.Context) ([]*model.AcademicField, error)
 }
 type SubjectResolver interface {
@@ -243,7 +243,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.Subjects(childComplexity, args["title"].(*string), args["faculty"].(*string), args["academicField"].(*string)), true
+		return e.complexity.Query.Subjects(childComplexity, args["title"].(string), args["faculty"].(string), args["academicField"].(string)), true
 
 	case "RelatedSubject.academicField":
 		if e.complexity.RelatedSubject.AcademicField == nil {
@@ -792,7 +792,7 @@ var sources = []*ast.Source{
 	{Name: "../schemas/mutation.graphqls", Input: ``, BuiltIn: false},
 	{Name: "../schemas/query.graphqls", Input: `type Query {
   subject(id: ID!): Subject!
-  subjects(title: String, faculty: String, academicField: String): [Subject!]!
+  subjects(title: String!, faculty: String!, academicField: String!): [Subject!]!
   academicFields: [AcademicField!]!
 }
 `, BuiltIn: false},
@@ -925,28 +925,28 @@ func (ec *executionContext) field_Query_subject_args(ctx context.Context, rawArg
 func (ec *executionContext) field_Query_subjects_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
-	var arg0 *string
+	var arg0 string
 	if tmp, ok := rawArgs["title"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("title"))
-		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		arg0, err = ec.unmarshalNString2string(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
 	args["title"] = arg0
-	var arg1 *string
+	var arg1 string
 	if tmp, ok := rawArgs["faculty"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("faculty"))
-		arg1, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		arg1, err = ec.unmarshalNString2string(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
 	args["faculty"] = arg1
-	var arg2 *string
+	var arg2 string
 	if tmp, ok := rawArgs["academicField"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("academicField"))
-		arg2, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		arg2, err = ec.unmarshalNString2string(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -1316,7 +1316,7 @@ func (ec *executionContext) _Query_subjects(ctx context.Context, field graphql.C
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().Subjects(rctx, fc.Args["title"].(*string), fc.Args["faculty"].(*string), fc.Args["academicField"].(*string))
+		return ec.resolvers.Query().Subjects(rctx, fc.Args["title"].(string), fc.Args["faculty"].(string), fc.Args["academicField"].(string))
 	})
 	if err != nil {
 		ec.Error(ctx, err)

--- a/graph/query.resolvers.go
+++ b/graph/query.resolvers.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/kafugen/ocwcentral/graph/generated"
 	"github.com/kafugen/ocwcentral/graph/model"
-	"github.com/kafugen/ocwcentral/utils"
 )
 
 // Subject is the resolver for the subject field.
@@ -23,11 +22,11 @@ func (r *queryResolver) Subject(ctx context.Context, id string) (*model.Subject,
 }
 
 // Subjects is the resolver for the subjects field.
-func (r *queryResolver) Subjects(ctx context.Context, title *string, faculty *string, academicField *string) ([]*model.Subject, error) {
-	if title == nil && faculty == nil && academicField == nil {
+func (r *queryResolver) Subjects(ctx context.Context, title string, faculty string, academicField string) ([]*model.Subject, error) {
+	if title == "" && faculty == "" && academicField == "" {
 		return nil, fmt.Errorf("at least one of the parameters must be specified")
 	}
-	subjects, err := r.sbU.GetBySearchParameter(utils.ConvertNilToZeroValue(title), utils.ConvertNilToZeroValue(faculty), utils.ConvertNilToZeroValue(academicField))
+	subjects, err := r.sbU.GetBySearchParameter(title, faculty, academicField)
 	if err != nil {
 		return nil, fmt.Errorf("failed on executing `GetBySearchParameter` func of SubjectUsecase: %w", err)
 	}

--- a/graph/schemas/query.graphqls
+++ b/graph/schemas/query.graphqls
@@ -1,5 +1,5 @@
 type Query {
   subject(id: ID!): Subject!
-  subjects(title: String, faculty: String, academicField: String): [Subject!]!
+  subjects(title: String!, faculty: String!, academicField: String!): [Subject!]!
   academicFields: [AcademicField!]!
 }


### PR DESCRIPTION
## Related Issue

## What
- subjects queryの最初でどれかのパラメーターは指定されてないといけないという判定がnilチェックはあったが空文字列チャックがなかった。
- nilと空文字列両方考慮するの大変なのと、shopifyのgraphqlガイドにも文字列はrequiredにして空文字列にしたほうが良いと書いてたので、パラメータをrequiredにしてnilチェックを空文字列チェックに変更。

## Memo
<!-- レビュワーに伝えたいことがあれば -->
