### PR TITLE
Fix a bug that prevents fetching random subjects when requesting more…

### DIFF
--- a/persistence/subject_repository_impl.go
+++ b/persistence/subject_repository_impl.go
@@ -305,7 +305,7 @@ func (sR SubjectRepositoryImpl) GetByRandom(
 	if err := stmt.Select(&subjectDTOs, parameters); err != nil {
 		return nil, fmt.Errorf("failed to execute statement: %w", err)
 	}
-	subjects := make([]*model.Subject, numSubjects)
+	subjects := make([]*model.Subject, len(subjectDTOs))
 	for i, subjectDTO := range subjectDTOs {
 		subject, err := sR.getSubjectFromDto(subjectDTO)
 		if err != nil {


### PR DESCRIPTION
# What
ランダム講義の取得で、存在する講義数より多い数をリクエストするとうまくいかない問題を解消しました。Thanks, @ooyamatakehisa.